### PR TITLE
fix: compare full date in expense equality

### DIFF
--- a/src/shared/helpers/index.spec.ts
+++ b/src/shared/helpers/index.spec.ts
@@ -25,6 +25,20 @@ describe('isExpenseEqual', () => {
     expect(isExpenseEqual(expense1, expense2)).toBeFalsy();
   });
 
+  it('should return false when time differs by minutes', () => {
+    const expense1: Expense = { comment: 'Test expense', category: 'Food', amount: 50, date: new Date('2023-01-01T10:00:00') };
+    const expense2: Expense = { comment: 'Test expense', category: 'Food', amount: 50, date: new Date('2023-01-01T10:01:00') };
+
+    expect(isExpenseEqual(expense1, expense2)).toBeFalsy();
+  });
+
+  it('should return false when years differ', () => {
+    const expense1: Expense = { comment: 'Test expense', category: 'Food', amount: 50, date: new Date('2023-01-01') };
+    const expense2: Expense = { comment: 'Test expense', category: 'Food', amount: 50, date: new Date('2024-01-01') };
+
+    expect(isExpenseEqual(expense1, expense2)).toBeFalsy();
+  });
+
   it('should handle undefined dates', () => {
     const expense1: Expense = { comment: 'Test expense', category: 'Food', amount: 50, date: undefined };
     const expense2: Expense = { comment: 'Test expense', category: 'Food', amount: 50, date: undefined };

--- a/src/shared/helpers/index.ts
+++ b/src/shared/helpers/index.ts
@@ -6,9 +6,10 @@ export function isExpenseEqual(e1: Expense, e2: Expense): boolean {
     e1.category === e2.category &&
     e1.amount === e2.amount &&
     e1.date?.getSeconds() === e2.date?.getSeconds() &&
-    e1.date?.getSeconds() === e2.date?.getSeconds() &&
+    e1.date?.getMinutes() === e2.date?.getMinutes() &&
     e1.date?.getHours() === e2.date?.getHours() &&
     e1.date?.getDate() === e2.date?.getDate() &&
-    e1.date?.getMonth() === e2.date?.getMonth()
+    e1.date?.getMonth() === e2.date?.getMonth() &&
+    e1.date?.getFullYear() === e2.date?.getFullYear()
   );
 }


### PR DESCRIPTION
## Summary
- fix `isExpenseEqual` to compare minutes and years too
- add tests for minute and year mismatches

## Testing
- `CHROME_BIN=$(which chromium-browser) npm test -- --browsers=ChromeHeadless --watch=false` *(fails: ChromeHeadless failed 2 times (cannot start))*

------
https://chatgpt.com/codex/tasks/task_e_68a38ac57200832d8cb2005a1aea87b9